### PR TITLE
aria/semantic changes to replace media queries, menu toggle, current nav, et al.

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -1,0 +1,43 @@
+/*
+ * Footer with social nav and copyright.
+ */
+export default () => {  
+    return (
+        <footer role='contentinfo'>
+            <div className="social-icons">
+                <a href="https://twitter.com/jamonholmgren">
+                    <img src="/static/twitter.png" alt="Jamon Holmgren on twitter"/>
+                </a>
+                <a href="https://github.com/jamonholmgren">
+                    <img src="/static/github.png" alt="Jamon Holmgren on github"/>
+                </a>
+                <a href="https://facebook.com/jamon.holmgren">
+                    <img src="/static/facebook.png" alt="Jamon Holmgren on facebook"/>
+                </a>
+            </div>
+
+            <div className="copyright">
+                &copy; {new Date().getFullYear()} Jamon Holmgren
+            </div>
+
+            <style jsx>{`
+                footer {
+                   margin-top: 1em; 
+                }
+                .social-icons {
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                }
+
+                .social-icons img {
+                    flex: 1;
+                }
+
+                .copyright {
+                    text-align: center;
+                }
+            `}</style>
+        </footer>
+    );
+}

--- a/components/header.js
+++ b/components/header.js
@@ -1,28 +1,23 @@
-import { useState } from "react";
 import Nav from "./nav";
 import Link from "next/link";
 
-export default () => {
-  const [menuOpen, setMenuOpen] = useState(false);
-
+import { withRouter } from 'next/router';
+// Use withRouter to wrap the Header component, so we can pass the current
+// pathname to the Nav component.
+function Header({ router }) {
   return (
     <header>
-      <div id="head">
+      <div id="links">
         <Link href="/">
-          <a>
-            <span className="title">Jamon Holmgren</span>
-          </a>
+          <h1>
+            <a className="title" role="link">Jamon Holmgren</a>
+          </h1>
         </Link>
-        <a
-          href="javascript:void(0);"
-          id="menu-toggle"
-          onClick={() => setMenuOpen(!menuOpen)}
-        >
-          MENU
-        </a>
-        <div id="nav" className={menuOpen ? "menu-open" : "menu-closed"}>
-          <Nav />
-        </div>
+
+        <nav role="nav">
+          {/* Pass current path here.  */}
+          <Nav current={router.pathname}/>
+        </nav>
       </div>
 
       <style jsx>{`
@@ -32,75 +27,32 @@ export default () => {
           font-family: "Roboto Mono", monospace;
           font-weight: 400;
         }
-        #head {
+        #links {
           flex: 1;
           align-items: center;
         }
-        :global(#head a) {
-          color: #000000;
-        }
+
         .title {
           display: inline-block;
-          font-size: 36px;
+          font-size: 2rem;
+          cursor: pointer;
           text-decoration: none;
           padding: 0 0;
           margin: 10px 0;
-          color: #000;
           vertical-align: middle;
           line-height: 1.4;
           border-width: 0 0 3px;
           border-color: #dadada;
           border-style: solid;
         }
-        :global(#nav) {
-          display: block;
-          float: right;
-          vertical-align: middle;
-          position: relative;
-          top: 10px;
-          height: auto;
-          overflow: hidden;
-          flex: 1;
-        }
-        :global(#menu-toggle) {
-          font-family: "Roboto Mono", monospace;
-          font-size: 12px;
-          display: none;
-          float: right;
-          padding: 10px;
-          text-decoration: none;
-          text-align: right;
-          position: relative;
-          top: 20px;
-        }
-        :global(#menu-toggle img) {
-          width: 25px;
-          height: 25px;
-        }
-        @media (max-width: 760px) {
-          .title {
-            font-size: 26px;
-          }
-          :global(#nav) {
-            display: flex;
-            height: 0;
-            transition: height 0.5s, opacity 0.5s;
-            float: none;
-          }
-          :global(#nav.menu-open) {
-            height: auto;
-            transition: height 0.5s, opacity 0.5s;
-          }
-          :global(#nav.menu-closed) {
-            height: 0;
-            opacity: 0;
-            transition: height 0.5s, opacity 0.5s;
-          }
-          :global(#menu-toggle) {
-            display: block;
-          }
+
+        nav {
+          display: flex;
+          transition: height 0.5s, opacity 0.5s;
         }
       `}</style>
     </header>
   );
 };
+
+export default withRouter(Header);

--- a/components/meta.js
+++ b/components/meta.js
@@ -29,30 +29,31 @@ export default props => (
         font-family: "Source Sans Pro", "Open Sans", sans-serif;
         /* font-family: "Playfair Display", Helvetica, Arial, sans-serif; */
 
-        font-size: 17px;
-        padding: 40px 10px;
+        font-size: 1rem;
+        padding: 1em 0.5em;
         margin: 0;
-        line-height: 1.5em;
+        line-height: 1.5;
         background-color: white;
       }
+      
       * {
         box-sizing: border-box;
       }
 
       h1,
       h2 {
+        font-size: 2rem;
         font-weight: normal;
-        line-height: 1.25em;
+        line-height: 1.25;
         font-family: "Roboto Mono", monospace;
       }
 
       a {
-        color: #6b3912;
+        color: firebrick;
       }
 
       p {
-        margin-top: 30px;
-        margin-bottom: 30px;
+        margin: 0.5em 0;
       }
 
       /* loading progress bar styles */

--- a/components/nav.js
+++ b/components/nav.js
@@ -1,9 +1,14 @@
 import Link from "next/link";
 
-const Item = ({ href, children }) => (
+// Nav component receives `current` as current router path
+// in order to add aria-current attributes to nav links.
+// @see https://tink.uk/using-the-aria-current-attribute/
+
+const Item = ({ href, current, children }) => {
+  return (
   <li>
     <Link href={href}>
-      <a>{children}</a>
+      <a aria-current={current ? 'page' : 'false'}>{children}</a>
     </Link>
 
     <style jsx>{`
@@ -15,41 +20,67 @@ const Item = ({ href, children }) => (
         padding: 10px 8px;
         font-size: 18px;
         text-decoration: underline;
-        color: #000;
         transition: 0.2s;
       }
       a:hover {
         transition: 0.2s;
-        color: #dadada;
+        /*
+         * This color is a placeholder value to contrast with the global a tag
+         * color of firebrick (see meta.js).
+         */
+        color: green;
+        font-weight: bold;
+      }
+
+      [aria-current="page"] {
+        color: inherit;
         font-weight: bold;
       }
     `}</style>
   </li>
-);
+  );
+};
 
-export default () => (
-  <ul>
-    <Item href="/beginnings">beginnings</Item>
-    <Item href="/now">now</Item>
-    <Item href="/tech">tech</Item>
-    <Item href="/talks">talks</Item>
-    <Item href="/connect">connect</Item>
+export default function Nav({ current }) {
+  // Use this ordered list for creating the ul Items dynamically, in order to
+  // set the aria-current attribute on each one  correctly.
+  const pages = [
+    'beginnings',
+    'now',
+    'tech',
+    'talks',
+    'connect'
+  ];
 
-    <style jsx>{`
-      ul {
-        list-style-type: none;
-        display: flex;
-        flex: 1;
-        text-align: center;
-      }
-      @media (max-width: 760px) {
+  return (
+    <ul>
+      {pages.map((page, i) => {
+        let href = '/' + page;
+        return (
+          <Item key={i} href={href} current={href == current}>{page}</Item>
+        )
+      })}
+
+      <style jsx>{`
         ul {
-          display: block;
-          padding-left: 0;
-          padding-right: 0;
-          text-align: right;
+          list-style-type: none;
+
+          /*
+             Have to remove user agent margin and padding when removing list
+             markers.
+          */
+          margin: 0;
+          padding: 0;
+
+          display: flex;
+          flex: 1;
+
+          /* Handle narrow viewport by wrapping without media queries */
+          flex-flow: row wrap;
+
+          text-align: center;
         }
-      }
-    `}</style>
-  </ul>
-);
+      `}</style>
+    </ul>
+  );
+}

--- a/components/page.js
+++ b/components/page.js
@@ -1,53 +1,27 @@
 import Header from "./header";
 import Meta from "./meta";
+import Footer from "./footer";
 
 export default props => {
   return (
-    <div className="main">
+    <div className="page">
       <Meta title={props.title} description={props.description} />
+      
       <Header />
 
-      <div className="page">{props.children}</div>
+      <main role='main' className="main">{props.children}</main>
 
-      <div className="social-icons">
-        <a href="https://twitter.com/jamonholmgren">
-          <img src="/static/twitter.png" />
-        </a>
-        <a href="https://github.com/jamonholmgren">
-          <img src="/static/github.png" />
-        </a>
-        <a href="https://facebook.com/jamon.holmgren">
-          <img src="/static/facebook.png" />
-        </a>
-      </div>
+      <Footer />
 
       <style jsx>{`
-        .main {
+        .page {
           margin: auto;
-          height: 100vh;
           max-width: 950px;
         }
 
-        .page {
+        .main {
           color: #000;
           padding: 3px 0px;
-        }
-
-        .social-icons {
-          display: flex;
-          align-items: center;
-          justify-content: center;
-        }
-
-        .social-icons img {
-          flex: 1;
-        }
-
-        @media (max-width: 760px) {
-          .main {
-            padding: 5px;
-            width: auto;
-          }
         }
       `}</style>
     </div>

--- a/pages/beginnings.js
+++ b/pages/beginnings.js
@@ -10,8 +10,8 @@ export default () => {
         I grew up just outside a small town in northwest Oregon, called
         Clatskanie. My dad was a millwright and eventually started his own small
         excavation business, and my mom took care of me and my eight siblings.
-        Yes, you read that right -- I have eight awesome siblings! Three sisters
-        and five brothers. And no, we're not Mormon nor Catholic -- we're
+        Yes, you read that right &mdash; I have eight awesome siblings! Three sisters
+        and five brothers. And no, we're not Mormon nor Catholic &mdash; we're
         Lutherans, actually.
       </p>
       <p>
@@ -21,16 +21,22 @@ export default () => {
         by vast swathes of uninhabited timberland. I spent my younger years
         exploring the woods with my dog and, later, some of my younger brothers.
       </p>
-      <img src="/static/dad-jamon-fish.jpg" id="dad-jamon-fish" />
-      <figcaption>My dad and me after a fishing trip</figcaption>
+      <img
+        src="/static/dad-jamon-fish.jpg"
+        aria-labelledby="dad-jamon-fish-caption"
+      />
+      <figcaption id="dad-jamon-fish-caption">My dad and me after a fishing trip</figcaption>
       <p>
         In the early 90s, my dad bought his first computer to do his small
         business books. I had already started to play around with the Apple IIes
         and Commodore 64 at my grade school, so this new 286 was of intense
         interest to me.
       </p>
-      <img src="/static/old-286-computer.png" id="first-286-computer" />
-      <figcaption>
+      <img
+        src="/static/old-286-computer.png"
+        aria-labelledby="first-286-computer-caption"
+      />
+      <figcaption id="first-286-computer-caption">
         My dad's first computer, a 286. I hooked it up to an LCD screen a few
         years ago and it still worked!
       </figcaption>
@@ -39,20 +45,20 @@ export default () => {
         Undeterred, I dug into batch files, reading the source code and trying
         to puzzle out what they did. I even tried to manipulate the machine code
         of a compiled exe file. Unfortunately, I learned the benefit of making a
-        good backup before doing that -- I permanently damaged a game and never
+        good backup before doing that &mdash; I permanently damaged a game and never
         did get it working again after that.
       </p>
       <img
         src="/static/jamon-drew-at-computer.jpg"
-        id="jamon-drew-at-computer"
+        aria-labelledby="jamon-drew-at-computer-caption"
       />
-      <figcaption>
+      <figcaption id="jamon-drew-at-computer-caption">
         My brother Drew and me playing Chuck Yeager's Air Combat on the 286
       </figcaption>
       <p>
         My dad's plans to make the 286 do all of his books quickly and easily
         didn't quite pan out, so he eventually went back and bought a more
-        capable computer -- one that could handle QuickBooks. This 486DX
+        capable computer &mdash; one that could handle QuickBooks. This 486DX
         computer came with QBasic! I was thrilled. From age twelve through my
         teenage years, I built hundreds of games, some small and some larger. I
         built text adventure games, top-down tank shooters, space games, a huge{" "}
@@ -83,7 +89,7 @@ export default () => {
       <p>
         My first jobs were menial labor. Changing tires and oil at a local tire
         shop, packing lumber for a house framing crew. Over time, I started
-        taking on side jobs using my computer programming skills -- usually
+        taking on side jobs using my computer programming skills &mdash; usually
         building something in MS Excel or Access, using Visual Basic for
         Applications. I think I charged $15/hour for those projects. For a 19
         year old at the time, I thought it was fair enough, and I got to code
@@ -101,10 +107,9 @@ export default () => {
       </p>
       <img
         src="/static/jamon-chyra-honeymoon.jpg"
-        alt="My wife Chyra and me on our honeymoon"
-        id="honeymoon"
+        aria-labelledby="honeymoon-caption"
       />
-      <figcaption>
+      <figcaption id="honeymoon-caption">
         Chyra and me on our honeymoon. Married nearly 16 years now!
       </figcaption>
       <p>
@@ -123,10 +128,9 @@ export default () => {
       </p>
       <img
         src="/static/desk-setup.jpg"
-        alt="My desk setup in those days"
-        id="family"
+        aria-labelledby="family-caption"
       />
-      <figcaption>My desk setup in those days</figcaption>
+      <figcaption id="family-caption">My desk setup in those days</figcaption>
       <p>
         I was "working remotely" and didn't even know the term at the time. I
         loved it!
@@ -166,12 +170,11 @@ export default () => {
       <img
         src="/static/jamonholmgren.jpg"
         alt="Portrait photo of Jamon Holmgren, quite handsome, or so my wife tells me"
-        id="jamon"
       />
 
       <img src="/static/jamon-family.JPG" alt="My family" id="jamon-family" />
-
       <figcaption>My family - my wife Chyra and our four kids</figcaption>
+
       <p className="next-steps">
         <em>
           <Link href="/now">

--- a/pages/connect.js
+++ b/pages/connect.js
@@ -5,17 +5,19 @@ import Page from "../components/page";
 export default () => {
   return (
     <Page title="Connect with me">
+      <h2>Connect with me</h2>
+
       <p>You can find me online any of these places:</p>
 
       <p>
-        <a href="https://twitter.com/jamonholmgren">Twitter</a> -- I tweet about
+        <a href="https://twitter.com/jamonholmgren">Twitter</a> &mdash; I tweet about
         software design and development mostly, with some humor, some remote
         work discussion, and generally friendly and upbeat tone. Follow me, I
         promise I’ll make it worth your while.
       </p>
 
       <p>
-        <a href="https://facebook.com/jamon.holmgren">Facebook</a> -- I post
+        <a href="https://facebook.com/jamon.holmgren">Facebook</a> &mdash; I post
         about my kids, family, amusing thoughts that come to my head, personal
         milestones, and a few other things. Feel free to friend request me
         there; I’m really not that private of a person.
@@ -23,18 +25,18 @@ export default () => {
 
       <p>
         <a href="http://community.infinite.red">Infinite Red Community Slack</a>
-        -- I started my company’s community slack and we talk mostly about tech
+        &mdash; I started my company’s community slack and we talk mostly about tech
         in there. Feel free to say hi if you join.
       </p>
 
       <p>
-        <a href="https://instagram.com/jamonholmgren">Instagram</a> -- I’m
+        <a href="https://instagram.com/jamonholmgren">Instagram</a> &mdash; I’m
         semi-active on there. Feel free to follow me, and I’ll probably follow
         you back.
       </p>
 
       <p>
-        <a href="https://medium.com/@jamonholmgren">Medium</a> -- I write
+        <a href="https://medium.com/@jamonholmgren">Medium</a> &mdash; I write
         occasionally there. Like Instagram, follow me and I’ll follow you back.
       </p>
     </Page>

--- a/pages/gym.js
+++ b/pages/gym.js
@@ -194,7 +194,7 @@ export default () => {
 
       <p>
         When folded against the wall, it takes up very little room. I don't
-        however fold it up very often -- there really isn't any point, since
+        however fold it up very often &mdash; there really isn't any point, since
         there's plenty of room to do everything we need to do, and we don't park
         in that garage bay. It takes about 2 minutes to fold up or unfold. The
         J-hooks are solid and it feels pro. I'm 6'-4" and the pull-up bar is

--- a/pages/index.js
+++ b/pages/index.js
@@ -59,7 +59,7 @@ export default () => {
         <a href="mailto:jamon@infinite.red">jamon@infinite.red</a>.
       </p>
 
-      <h4>Or...</h4>
+      <h3>Or...</h3>
 
       <ul>
         <li>
@@ -87,16 +87,18 @@ export default () => {
         <li>
           Watch a 5 minute lightning talk I gave at{" "}
           <a href="https://www.youtube.com/watch?v=DOgT_K5tLxU">ElixirConf</a>
-        </li>{" "}
-        or other{" "}
-        <Link href="/talks">
-          <a>talk</a>
-        </Link>
-        .
+          {" "}
+          or other{" "}
+          <Link href="/talks">
+            <a>talks</a>
+          </Link>.
+        </li>
       </ul>
 
+      <hr />
+
       <p>
-        I built this website in <a href="https://nextjs.org">Next.js</a> and
+        P.S. I built this website in <a href="https://nextjs.org">Next.js</a> and
         I've had a great experience with it.{" "}
         <a href="https://twitter.com/jamonholmgren/status/1065447628966514688">
           Upgrading
@@ -108,6 +110,13 @@ export default () => {
       </p>
 
       <style jsx>{`
+        hr {
+          background: lightgray;
+          height: 0.15rem;
+          border: none;
+          margin: 1em 0.25em;
+        }
+
         .opening {
           font-weight: normal;
           font-style: italic;
@@ -117,17 +126,16 @@ export default () => {
           display: flex;
           justify-content: space-between;
           flex-wrap: wrap;
+          margin: 2em 0;
         }
         .photo-wall img {
-          width: 300px;
-          height: 300px;
-        }
+          /* Let browser handle scaling... */
+          height: 33%;
+          width: 33%;
 
-        @media (max-width: 920px) {
-          .photo-wall img {
-            width: 33%;
-            height: 33%;
-          }
+          /* ...up to our max dimensions. */
+          max-height: 300px;
+          max-width: 300px;
         }
       `}</style>
     </Page>

--- a/pages/now.js
+++ b/pages/now.js
@@ -2,6 +2,16 @@ import React from "react";
 import Page from "../components/page";
 import Link from "next/link";
 // import YouTube from "react-youtube";
+/*
+  Something to keep your eye on.
+  
+  The console is throwing warnings about `componentWillUpdate()` which will be
+  deprecated in React 17 - maybe - and TweetEmbed v-1.2.2 still uses it, at
+  https://github.com/capaj/react-tweet-embed/blob/master/src/tweet-embed.tsx#L99.
+
+  See the reactjs blog for more information,
+  https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.
+ */
 import TweetEmbed from "react-tweet-embed";
 
 export default () => {
@@ -51,8 +61,10 @@ export default () => {
         </li>
         <li>Our family has a cat, Willow, who is two years old.</li>
         <li>
-          I'm continuing to work out in my <Link href="/gym">new home gym</Link>
-          .
+          I'm continuing to work out in my
+          <Link href="/gym">
+            <a>new home gym</a>
+          </Link>.
         </li>
         <li>
           <Link href="/tech">

--- a/pages/talks.js
+++ b/pages/talks.js
@@ -7,11 +7,11 @@ import TweetEmbed from "react-tweet-embed";
 export default () => {
   return (
     <Page
-      title="Talks -- recent and upcoming"
+      title="Talks &mdash; Recent and Upcoming"
       description="Talks I have given recently as well as upcoming talks and meetups"
     >
-      <h1>Talks -- Recent and Upcoming</h1>
-
+      <h2>Talks &mdash; Recent and Upcoming</h2>
+      
       <p>
         I sometimes give talks at conferences (when I'm not{" "}
         <a href="https://infinite.red/ChainReactConf">helping organize one</a>)
@@ -40,28 +40,36 @@ export default () => {
           . It's a lovely small conference. I'll post the video when available.
         </li>
         <li>
+          <p>
           In September, I spoke at{" "}
           <a href="https://reactlive.nl/">React Live Amsterdam!</a> It was
-          great! Here's the video: <br />
+          great! Here's the video:
+          </p>
+          <br />
           <YouTube videoId="Pb8MWkQ9GOc" />
           <br />
           <TweetEmbed id="1179755402516422659" />
         </li>
         <li>
+          <p>
           On the same trip and before React Live Amsterdam, I gave a talk at{" "}
           <a href="https://react-native.eu/">React Native EU</a> in September.
-          Check it out! <br />
+          Check it out!
+          </p>
+          <br />
           <YouTube videoId="qzkDssF8y9k" />
           <br />
           <TweetEmbed id="1181638898272747521" />
         </li>
         <li>
+          <p>
           I was on React Roundup, a podcast with David Ceddia and Lucas Reis, in
           August. I talk about Ignite, React Finland, MobX-State-Tree, and my
           coding background. Have a listen!{" "}
           <a href="https://devchat.tv/react-round-up/rru-076-ignite-and-the-react-community-with-jamon-holmgren/">
             RRU 076: Ignite and the React Community with Jamon Holmgren
           </a>
+          </p>
         </li>
         <li>
           I was a guest on the panel at{" "}
@@ -71,33 +79,41 @@ export default () => {
           for the July 30, 2019 edition.
         </li>
         <li>
+          <p>
           I was interviewed in June for DistantJobs podcast. They just launched
-          a new website -- check it out!{" "}
+          a new website &mdash; check it out!{" "}
+          </p>
           <a href="https://distantjob.com/blog/podcasts/leading-a-fully-remote-team-with-jamon-holmgren/">
             Leading a Fully Remote Team with Jamon Holmgren
           </a>
         </li>
         <li>
+          <p>
           I am an organizer and was on the speaker panel at{" "}
           <a href="https://infinite.red/ChainReactConf">Chain React 2019</a> in
           July, 2019! It was an amazing conference all around. Here's the video
           of my panel appearance.
+          </p>
           <br />
           <YouTube videoId="Jm19JlVukak" />
           <br />
           <TweetEmbed id="1149780351633391618" />
         </li>
         <li>
+          <p>
           I was a backup speaker at{" "}
           <a href="https://runningremote.com">RunningRemote</a> in Bali in June.
           While I didn't give a talk, I did get a chance to be at that amazing
           conference, which I really loved.
+          </p>
           <br />
           <TweetEmbed id="1144773212791697408" />
         </li>
         <li>
+          <p>
           I spoke at <a href="https://react-finland.fi">React Finland 2019</a>!
           You can see the video here:
+          </p>
           <br />
           <YouTube videoId="gTG8_9Zv0YI" />
           <br />
@@ -107,12 +123,14 @@ export default () => {
           </a>
         </li>
         <li>
+          <p>
           While I was in Finland, I also gave a talk about React Native WebView
           at{" "}
           <a href="https://meetabit.com/events/react-helsinki-april-2019">
             React Helsinki
           </a>
           ! They have a video, which I will post when it's available.
+          </p>
           <br />
           {/* <YouTube videoId="gTG8_9Zv0YI" /> */}
           <br />
@@ -130,12 +148,14 @@ export default () => {
           February 29. It went really well!
         </li>
         <li>
+          <p>
           I was the first speaker at the new meetup in Vancouver, Washington,
           called{" "}
           <a href="https://www.meetup.com/Vancouver-Full-Stack/events/258023247/">
             Vancouver Full Stack
           </a>
           , ! I spoke about Modern JavaScript.
+          </p>
           <br />
           <YouTube videoId="wXvXcrjgiXw" />
         </li>
@@ -182,9 +202,11 @@ export default () => {
           - September 29, 2017 - Portland, Oregon
         </li>
         <li>
+          <p>
           <a href="https://elixirconf.com">ElixirConf 2017</a> September 7-8,
           2017 - Bellevue, Washington - I gave a lightning talk titled "Demoing
           Thesis - a Phoenix CMS".
+          </p>
           <br />
           <YouTube videoId="DOgT_K5tLxU" />
         </li>
@@ -238,6 +260,16 @@ export default () => {
           <a href="https://remote.works/episode/2/transcript">transcript</a>.
         </li>
       </ul>
+
+      <style jsx>{`
+        li {
+          margin-bottom: 2em;
+        }
+
+        br ~ * {
+          margin-top: 2em;
+        }
+      `}</style>
     </Page>
   );
 };

--- a/pages/tech.js
+++ b/pages/tech.js
@@ -9,7 +9,7 @@ export default () => {
       title="My favorite tech"
       description="All about my favorite technologies and what I am currently learning"
     >
-      <h1>My Favorite Tech (for now)</h1>
+      <h2>My Favorite Tech (for now)</h2>
 
       <p>
         If there's one thing I've learned, it's that I love to explore new


### PR DESCRIPTION
@jamonholmgren 

Here it is  - 12 files in all. 

This is the first time I've used Yarn and Next - getting into flow did not take very long.

The main thing I went after were accessibility and semantic issues.

- There's a new footer component for the social icons and a copyright.
- The menu toggle has been removed - nav links should flow like liquid layout days of yore.
- Nav is changed to generate links dynamically and calculate `aria-current="page|false"` attribute given the `href` matches the router's current pathname.
- In page.js, the roles of "page" and "main" are swapped to reflect their HTML5 roles.
- Most of the rest are heading level fixes (I used the axe extension on chrome), additional whitespace and hr and p tags for easier scanning of long pages, and reducing CSS (basic link color is in meta.js) and replacing media queries (see the photo wall img fix in index.js, e.g.).

Let me know any questions, comments, observations.

